### PR TITLE
Use hex fixed for hex ids to ensure 16 characters

### DIFF
--- a/opentracing/OpenTracing/Types.hs
+++ b/opentracing/OpenTracing/Types.hs
@@ -27,12 +27,12 @@ where
 import           Control.Lens
 import           Data.Aeson                 (ToJSON (..))
 import           Data.Aeson.Encoding
+import           Data.ByteString.Builder    as B
 import qualified Data.IP                    as IP
 import           Data.Monoid
 import           Data.Text                  (Text)
 import qualified Data.Text                  as Text
-import qualified Data.Text.Lazy.Builder     as TB
-import qualified Data.Text.Lazy.Builder.Int as TB
+import qualified Data.Text.Lazy.Encoding    as E
 import qualified Data.Text.Read             as TR
 import           Data.Word
 import           Network                    (HostName)
@@ -119,7 +119,7 @@ instance AsHex TraceID where
 instance AsHex Word64 where
     _Hex = prism' enc dec
       where
-        enc = Hex . view strict . TB.toLazyText . TB.hexadecimal
+        enc = Hex . view strict . E.decodeUtf8 . B.toLazyByteString . B.word64HexFixed
         dec = either (const Nothing) (pure . fst) . TR.hexadecimal . unHex
     {-# INLINE _Hex #-}
 


### PR DESCRIPTION
Resolves #17 

I thought about switching the `Text` inside `Hex` to `ByteString` entirely, but that looked like a bunch of changes so I figured I'd do this first. 
```
prng <- liftIO createSystemRandom
let newWord :: IO Word64 = liftIO (uniform prng)
idLengths <- map (length . toLazyByteString . word64HexFixed) <$> replicateM 10000 newWord
filter (/= 16) idLengths 
> []
```
