### PR TITLE
Stack resolver for GHC 8.8 and Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ os: linux
 dist: bionic
 
 env:
-  - PACKAGE=.
   - PACKAGE=opentracing
   - PACKAGE=opentracing-cloudtrace
   - PACKAGE=opentracing-examples
@@ -33,7 +32,8 @@ script:
   - if [ ! -d "$DIR" ]; then mkdir -p $DIR; fi
   - stack upgrade
   - hash -r
-  - cd $PACKAGE
-  - stack setup
-  - stack build
-  - stack test
+  - travis_retry eval $"stack setup"
+  - travis_retry eval $"stack build --dependencies-only $PACKAGE"
+  - stack build $PACKAGE
+  - travis_retry eval $"stack test --no-run-tests $PACKAGE"
+  - stack test $PACKAGE

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,39 @@
+# https://docs.haskellstack.org/en/stable/travis_ci/
+
+language: generic
+cache:
+  directories:
+  - $HOME/.local/bin
+  - $HOME/.stack
+  - $TRAVIS_BUILD_DIR/.stack-work
+
+addons:
+  apt:
+    packages:
+      - haskell-stack
+
+os: linux
+
+dist: bionic
+
+env:
+  - PACKAGE=.
+  - PACKAGE=opentracing
+  - PACKAGE=opentracing-cloudtrace
+  - PACKAGE=opentracing-examples
+  - PACKAGE=opentracing-http-client
+  - PACKAGE=opentracing-jaeger
+  - PACKAGE=opentracing-wai
+  - PACKAGE=opentracing-zipkin-common
+  - PACKAGE=opentracing-zipkin-v1
+  - PACKAGE=opentracing-zipkin-v2
+
+script:
+  - export DIR=~/.local/bin
+  - if [ ! -d "$DIR" ]; then mkdir -p $DIR; fi
+  - stack upgrade
+  - hash -r
+  - cd $PACKAGE
+  - stack setup
+  - stack build
+  - stack test

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # OpenTracing for Haskell
 
+[![Build Status](https://travis-ci.com/kim/opentracing.svg?branch=master)](https://travis-ci.com/kim/opentracing)
+
 [OpenTracing](http://opentracing.io) is an attempt to define a common API to
 instrument code for
 [Dapper](https://research.google.com/pubs/pub36356.html)-style distributed

--- a/stack.yaml
+++ b/stack.yaml
@@ -11,6 +11,12 @@ packages:
 - opentracing-zipkin-v1
 - opentracing-zipkin-v2
 extra-deps:
-- thrift-0.12.0
-- optparse-applicative-0.14.0.0
-resolver: lts-9.21
+- gogol-0.5.0
+- gogol-cloudtrace-0.5.0@sha256:1fe6b948c71323b9140f1fde490405281a4d5904f004c2735fe783b1b4ae93ed,1915
+- gogol-core-0.5.0@sha256:c0a919cd89a33de7fd6ee925abdb48b0eb5d1002a016124acbdff568f267e4c7,2821
+- gogol-logging-0.5.0
+- network-2.8.0.1@sha256:0f165dffa752d8cde30c2bde86f80609c4f1dc5eeb3182d593041f97839c5b3b,3011
+- thrift-0.13.0@sha256:e7c1f0f3562dd3fe412ffbd6743c87e9c65f43798593c06f8be8c547be2cd19e,2742
+- vinyl-0.13.0@sha256:0f247cd3f8682b30881a07de18e6fec52d540646fbcb328420049cc8d63cd407,3724
+
+resolver: lts-16.15


### PR DESCRIPTION
Builds fail for `opentracing-cloudtrace` and `opentracing-examples`.  The others succeed: https://travis-ci.com/github/peterbecich/opentracing/builds/185905896

The Travis CI config is somewhat similar to https://github.com/google/codeworld/blob/master/.travis.yml