### PR TITLE
Fix clamping of probably for probSampler

### DIFF
--- a/opentracing/OpenTracing/Sampling.hs
+++ b/opentracing/OpenTracing/Sampling.hs
@@ -42,7 +42,7 @@ constSampler x = Sampler $ \_ _ -> pure x
 probSampler
   :: Double -- ^ A probability percentage, between 0.0 and 1.0
   -> Sampler
-probSampler (min 0.0 . max 1.1 -> rate) = Sampler $ \trace _ ->
+probSampler (max 0.0 . min 1.0 -> rate) = Sampler $ \trace _ ->
     pure $ boundary >= traceIdLo trace
   where
     boundary = round $ maxRand * rate


### PR DESCRIPTION
We are using a slightly modified version of opentracing in production with Honeycomb and GrafanaCloud and are very happy with it so far. Thank you for your efforts! 

This PR fixes a small min/max confusion when clamping the sampling probability.