### PR TITLE
ci: drop support for GHC 8.0

### DIFF
--- a/.github/workflows/matrix.yaml
+++ b/.github/workflows/matrix.yaml
@@ -5,29 +5,20 @@ on: pull_request
 jobs:
   linux:
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.versions.allow-failure }}
     strategy:
       fail-fast: false
       matrix:
         versions:
-          # For historical purposes: the library was developed on GHC 8.0.2
-          - ghc: '8.0'
-            cabal: '3.4'
-            allow-failure: false
           # MSHV: three major versions
           - ghc: '8.6'
             cabal: '3.4'
-            allow-failure: false
           - ghc: '8.8'
             cabal: '3.4'
-            allow-failure: false
           - ghc: '8.10'
             cabal: '3.4'
-            allow-failure: false
-          # GHC 9 is a "super-major" release, needs some CPP
+          # Latest
           - ghc: '9.0'
             cabal: '3.4'
-            allow-failure: true
     steps:
     - uses: actions/checkout@v2
 

--- a/opentracing-examples/Simple.hs
+++ b/opentracing-examples/Simple.hs
@@ -5,7 +5,6 @@ module Main where
 import Backends
 import Control.Concurrent     (threadDelay)
 import Control.Monad.IO.Class (liftIO)
-import Data.Semigroup         ((<>))
 import OpenTracing
 import Options.Applicative
 

--- a/opentracing-examples/src/Backends.hs
+++ b/opentracing-examples/src/Backends.hs
@@ -11,7 +11,6 @@ module Backends
 where
 
 import           Control.Lens
-import           Data.Semigroup         ((<>))
 import           Data.Text              (Text)
 import           Network.HTTP.Client    (defaultManagerSettings, newManager)
 import           OpenTracing

--- a/opentracing-http-client/Network/HTTP/Client/OpenTracing.hs
+++ b/opentracing-http-client/Network/HTTP/Client/OpenTracing.hs
@@ -11,7 +11,6 @@ import           Control.Applicative
 import           Control.Lens                 (over, set, view)
 import           Control.Monad.IO.Class
 import           Control.Monad.Reader
-import           Data.Semigroup               ((<>))
 import qualified Data.Text                    as Text
 import           Data.Text.Encoding           (decodeUtf8)
 import           Network.HTTP.Client.Internal

--- a/opentracing-jaeger/src/OpenTracing/Jaeger/AgentReporter.hs
+++ b/opentracing-jaeger/src/OpenTracing/Jaeger/AgentReporter.hs
@@ -32,7 +32,6 @@ import           Control.Exception.Safe
 import           Control.Lens                   (makeLenses, view)
 import           Control.Monad.IO.Class
 import           Data.ByteString.Builder
-import           Data.Semigroup
 import           Data.Text                      (Text)
 import qualified Data.Vector                    as Vector
 import qualified Jaeger.Types                   as Thrift

--- a/opentracing-jaeger/src/OpenTracing/Jaeger/CollectorReporter.hs
+++ b/opentracing-jaeger/src/OpenTracing/Jaeger/CollectorReporter.hs
@@ -35,7 +35,6 @@ import           Control.Monad.Catch
 import           Control.Monad.IO.Class
 import           Data.ByteString.Lazy           (fromStrict)
 import           Data.ByteString.Builder
-import           Data.Monoid
 import           Data.Text                      (Text)
 import           Data.Vector                    (fromList)
 import qualified Jaeger.Types                   as Thrift

--- a/opentracing-jaeger/src/OpenTracing/Jaeger/Propagation.hs
+++ b/opentracing-jaeger/src/OpenTracing/Jaeger/Propagation.hs
@@ -15,7 +15,6 @@ where
 import           Control.Lens
 import           Data.Bits
 import qualified Data.HashMap.Strict     as HashMap
-import           Data.Monoid
 import           Data.Text               (Text, isPrefixOf)
 import qualified Data.Text               as Text
 import qualified Data.Text.Read          as Text

--- a/opentracing-zipkin-v1/src/OpenTracing/Zipkin/V1/HttpReporter.hs
+++ b/opentracing-zipkin-v1/src/OpenTracing/Zipkin/V1/HttpReporter.hs
@@ -38,7 +38,6 @@ import Control.Monad.Catch
 import Control.Monad.IO.Class
 import Data.ByteString.Builder
 import Data.ByteString.Lazy         (fromStrict)
-import Data.Monoid
 import Network.HTTP.Client          hiding (port)
 import Network.HTTP.Types
 import OpenTracing.Log

--- a/opentracing-zipkin-v1/src/OpenTracing/Zipkin/V1/Thrift.hs
+++ b/opentracing-zipkin-v1/src/OpenTracing/Zipkin/V1/Thrift.hs
@@ -26,7 +26,6 @@ import qualified Data.HashMap.Strict      as HashMap
 import           Data.Int
 import qualified Data.IP                  as IP
 import           Data.List.NonEmpty       (NonEmpty (..))
-import           Data.Semigroup           ((<>))
 import           Data.Text.Encoding       (decodeUtf8, encodeUtf8)
 import qualified Data.Vector              as Vector
 import           OpenTracing.Log

--- a/opentracing-zipkin-v2/OpenTracing/Zipkin/V2/HttpReporter.hs
+++ b/opentracing-zipkin-v2/OpenTracing/Zipkin/V2/HttpReporter.hs
@@ -43,7 +43,6 @@ import qualified Data.ByteString.Base64.Lazy as B64
 import           Data.ByteString.Builder
 import           Data.Map.Lens               (toMapOf)
 import           Data.Maybe                  (catMaybes)
-import           Data.Monoid
 import           Data.Text.Lazy.Encoding     (decodeUtf8)
 import           Data.Text.Strict.Lens       (packed, utf8)
 import           Network.HTTP.Client

--- a/opentracing/OpenTracing/Propagation.hs
+++ b/opentracing/OpenTracing/Propagation.hs
@@ -113,7 +113,7 @@ carrier
     => proxy c -- ^ Proxy for the carrier type @c@.
     -> r -- ^ The application context
     -> Prism' c SpanContext
-carrier _c = fromCarrier . view (propagation . rlens)
+carrier _c r = fromCarrier $ view (propagation . rlens) r
 
 -- | Serialize a `SpanContext` into the format `c` using a serializer from
 -- the application context.

--- a/opentracing/OpenTracing/Propagation.hs
+++ b/opentracing/OpenTracing/Propagation.hs
@@ -62,7 +62,6 @@ import qualified Data.CaseInsensitive    as CI
 import           Data.HashMap.Strict     (HashMap)
 import qualified Data.HashMap.Strict     as HashMap
 import           Data.Maybe              (catMaybes)
-import           Data.Monoid
 import           Data.Proxy
 import           Data.Text               (Text, isPrefixOf, toLower)
 import           Data.Text.Encoding      (decodeUtf8, encodeUtf8)

--- a/opentracing/OpenTracing/Reporting/Batch.hs
+++ b/opentracing/OpenTracing/Reporting/Batch.hs
@@ -39,7 +39,6 @@ import Control.Lens
 import Control.Monad
 import Control.Monad.IO.Class
 import Data.ByteString.Builder
-import Data.Semigroup
 import Data.Time                (NominalDiffTime)
 import Data.Word
 import OpenTracing.Span

--- a/opentracing/OpenTracing/Reporting/Stdio.hs
+++ b/opentracing/OpenTracing/Reporting/Stdio.hs
@@ -18,7 +18,6 @@ import Data.Aeson                 (toEncoding)
 import Data.Aeson.Encoding
 import Data.ByteString.Lazy.Char8 (hPutStrLn)
 import Data.Foldable              (toList)
-import Data.Semigroup             ((<>))
 import GHC.Stack                  (prettyCallStack)
 import OpenTracing.Log
 import OpenTracing.Span

--- a/opentracing/OpenTracing/Tags.hs
+++ b/opentracing/OpenTracing/Tags.hs
@@ -90,7 +90,6 @@ import           Data.HashMap.Strict         (HashMap)
 import qualified Data.HashMap.Strict         as HashMap
 import           Data.Int                    (Int64)
 import           Data.Monoid                 (First)
-import           Data.Semigroup              (Semigroup)
 import           Data.Text                   (Text)
 import qualified Data.Text                   as Text
 import           Data.Text.Encoding          (decodeUtf8, encodeUtf8)

--- a/opentracing/OpenTracing/Types.hs
+++ b/opentracing/OpenTracing/Types.hs
@@ -29,7 +29,6 @@ import           Data.Aeson                 (ToJSON (..))
 import           Data.Aeson.Encoding
 import           Data.ByteString.Builder    as B
 import qualified Data.IP                    as IP
-import           Data.Semigroup             (Semigroup, (<>))
 import           Data.Text                  (Text)
 import qualified Data.Text                  as Text
 import qualified Data.Text.Lazy.Encoding    as E


### PR DESCRIPTION
`pinch` was introduced in #34, which doesn't build under 8.0
