### PR TITLE
Fix build for GHC 9

### DIFF
--- a/opentracing/OpenTracing/Propagation.hs
+++ b/opentracing/OpenTracing/Propagation.hs
@@ -113,7 +113,7 @@ carrier
     => proxy c -- ^ Proxy for the carrier type @c@.
     -> r -- ^ The application context
     -> Prism' c SpanContext
-carrier _c = fromCarrier . view (propagation . rlens)
+carrier _c r = fromCarrier $ view (propagation . rlens) r
 
 -- | Serialize a `SpanContext` into the format `c` using a serializer from
 -- the application context.


### PR DESCRIPTION
Eta-expand the `carrier` prism due to the "simplified subsumption
proposal".
